### PR TITLE
Disambiguate the Label class.

### DIFF
--- a/Tools/DataMorphose/plugins/Visualizer/src/Visualizer.cs
+++ b/Tools/DataMorphose/plugins/Visualizer/src/Visualizer.cs
@@ -94,7 +94,7 @@ namespace DataMorphose.Plugins.Visualizer
       nbLeftDock.Add(scroll);;
       
       this.propertyGrid = new SolidV.Gtk.InspectorGrid.InspectorGrid();
-      nbLeftDock.AppendPage(propertyGrid, new Label("Properties"));
+      nbLeftDock.AppendPage(propertyGrid, new Gtk.Label("Properties"));
       nbLeftDock.ShowAll();
     }
 


### PR DESCRIPTION
We have added the SolidV.MVC.Label class and this causes compilation errors.